### PR TITLE
Hotfix/debug almost0mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Visit the [project webpage](http://rpg.ifi.uzh.ch/unsupervised_detection.html) f
 conda case;
 ```bash
 conda env create -f environment.yml
+conda activate contextual-information-separation
 bash ./scripts/test_DAVIS2016_raw.sh
 ```
 you can even run inference for no annotated video.

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - cudatoolkit=10.1
   - python-gflags
   - keras=2.2.4
-  - gdown
+  - gdown=5.0.1 # 4.6.4 has a bug.
   - pillow

--- a/test_generator.py
+++ b/test_generator.py
@@ -29,7 +29,7 @@ def compute_IoU(gt_mask, pred_mask_f, threshold=0.1):
         annotation = pred_mask_compl
 
     if np.isclose(np.sum(annotation),0) and np.isclose(np.sum(gt_mask),0):
-        return 1
+        return 1, annotation
     else:
         return np.sum((annotation & gt_mask)) / \
                 np.sum((annotation | gt_mask),dtype=np.float32), annotation


### PR DESCRIPTION
# Objective
Debug runtime error.

# Original Error 
It happend below error when running test_video.py; TypeError: cannot unpack non-iterable int object

# Cause
The cause was in compute_IoU(), it returns 1 in some case; [test_generator.py](http://test_generator.py/) l.32
(   if np.isclose(np.sum(annotation),0) and np.isclose(np.sum(gt_mask),0):
        return 1)
 but it assumes 2 outputs in [test_generator.py](http://test_generator.py/) l.84
(iou, out_mask = compute_IoU).

# Fixation
return 2 values in all case in conput_IoU(); 
( return 1, annotation)